### PR TITLE
Fix command syntax errors with helm 3.1.2

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -6,6 +6,7 @@ various workloads. Think of helm as a package manager for deploying kubernetes p
 The SysFlow telemetry infrastructure is designed such that it should be deployable in any cloud environment. It has been tested on IBM Cloud, and as time permits, we will test it on other 
 public/private cloud offerings. There are likely some minor differences in how the authentication works on each cloud which could require changes to these charts.
 
+NOTE: This document has been tested with helm version 3.1.  Some helm commands may not work with other versions of helm.  We've tested the framework on k8s version 1.16.
 
 ## Prerequisites
 

--- a/helm/deleteExporterChart
+++ b/helm/deleteExporterChart
@@ -17,4 +17,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-helm del --purge sf-exporter-chart
+helm uninstall sf-exporter-chart -n sysflow

--- a/helm/installExporterChart
+++ b/helm/installExporterChart
@@ -51,13 +51,8 @@ enabled='N'
 tlsStatus=$(helm ls 2>&1)
 if [[ "$tlsStatus" != "Error: transport is closing" ]]; then
     read -p 'Warning: Helm TLS is not enabled. Do you want to continue? [y/N] ' enabled
-    if [ "$enabled" == "y" ]
+    if [ "$enabled" != "y" ]
     then
-        helm init --client-only
-        echo "Sleeping for 10 seconds so that tiller pod is ready"
-        sleep 10
-        tls=''
-    else
         echo "Setup helm TLS. Follow https://helm.sh/docs/tiller_ssl/"
         exit 1
     fi
@@ -70,4 +65,4 @@ else
     echo "Namespace 'sysflow' created successfully"
 fi
 
-helm install -n  sf-exporter-chart -f sf-exporter-chart/values.yaml.local --namespace sysflow --set sfexporter.s3AccessKey=$s3AccessKey --set sfexporter.s3SecretKey=$s3SecretKey --set sfexporter.s3Endpoint=$s3Endpoint --set sfexporter.s3Location=$s3Region --debug sf-exporter-chart
+helm install sf-exporter-chart -f sf-exporter-chart/values.yaml.local --namespace sysflow --set sfexporter.s3AccessKey=$s3AccessKey --set sfexporter.s3SecretKey=$s3SecretKey --set sfexporter.s3Endpoint=$s3Endpoint --set sfexporter.s3Location=$s3Region --debug ./sf-exporter-chart

--- a/helm/sf-exporter-chart/templates/daemonset-agents.yaml
+++ b/helm/sf-exporter-chart/templates/daemonset-agents.yaml
@@ -166,7 +166,7 @@ spec:
           readOnly: false
         - mountPath: "/run/secrets/k8s"
           name: secrets
-          subpath: k8s
+          subPath: k8s
           readOnly: true
         env:
         - name: S3_ENDPOINT


### PR DESCRIPTION
Here is my test procedure:
1. tar and copy /sf-deployments/ from local to my OCP infrastructure node.
2. make sure the installed kubectl version is 1.6 and helm version is 3.1.2 on the infra node.
3. prepare values.yaml.local
4. ./installExporterChart and check pods status
5. ./deleteExporterChart and check pods status

This changes basically make 4) and 5) work with helm 3.1.2.
Thank you for reviews.