### PR TITLE
Remove dependancy on secrets.yaml in helm operator

### DIFF
--- a/operator/helm-charts/sf-exporter-chart/templates/daemonset-agents.yaml
+++ b/operator/helm-charts/sf-exporter-chart/templates/daemonset-agents.yaml
@@ -1,22 +1,3 @@
-#
-# Copyright (C) 2019 IBM Corporation.
-#
-# Authors:
-# Frederico Araujo <frederico.araujo@ibm.com>
-# Teryl Taylor <terylt@ibm.com>
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
 {{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
@@ -150,11 +131,16 @@ spec:
         - mountPath: {{ .Values.sfexporter.outDir }}
           name: data
           readOnly: false
-        - mountPath: "/run/secrets/k8s"
-          name: secrets
-          #subpath: k8s
-          readOnly: true
+#       - mountPath: "/run/secrets/k8s"
+#         name: secrets
+#         readOnly: true
         env:
+        - name: EXPORT_TYPE
+          value: {{ .Values.sfexporter.exportType }}
+        - name: SYSLOG_HOST
+          value: {{ .Values.sfexporter.syslogHost }}
+        - name: SYSLOG_PORT
+          value: "{{ .Values.sfexporter.syslogPort }}"
         - name: S3_ENDPOINT
           value: {{ .Values.sfexporter.s3Endpoint }}
         - name: S3_PORT
@@ -202,14 +188,14 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
       volumes:
-      - name: secrets
-        secret:
-          secretName: {{ template "sf-exporter-chart.fullname" . }}-secrets
-          items:
-          - key: s3_access_key
-            path: "s3_access_key"
-          - key: s3_secret_key
-            path: "s3_secret_key"
+#     - name: secrets
+#       secret:
+#         secretName: {{ template "sf-exporter-chart.fullname" . }}-secrets
+#         items:
+#         - key: s3_access_key
+#           path: "s3_access_key"
+#         - key: s3_secret_key
+#           path: "s3_secret_key"
       - name: data
         emptyDir:
           medium: Memory

--- a/operator/helm-charts/sf-exporter-chart/values.yaml
+++ b/operator/helm-charts/sf-exporter-chart/values.yaml
@@ -12,6 +12,7 @@ sfcollector:
   tag: edge
   imagePullPolicy: Always
 sfexporter:
+  exportType: s3
   interval: 30
   outDir: /mnt/data/
   repository: sysflowtelemetry/sf-exporter
@@ -22,6 +23,8 @@ sfexporter:
   s3Port: 9000
   s3SecretKey: <s3_secret_key>
   s3Secure: "false"
+  syslogHost: localhost
+  syslogPort: 514
   tag: edge
   imagePullPolicy: Always
 tmpfsSize: 500Mi


### PR DESCRIPTION
- remove dependency on secrets.yaml since it is not in operator helm chart
- remove copy-right in yaml to fit community convention

What I test passed is to see rsyslog printing with sysflow operator deployment.
This PR is required to build sysflowtelemetry/oc-operator:latest image with modified charts,
so that PODs can enter running state with default config values.

Signed-off-by: Carlos Hsiao <weii666@gmail.com>