### PR TITLE
Invalid default FILTER for collector

### DIFF
--- a/docker/config/.env.collector
+++ b/docker/config/.env.collector
@@ -1,6 +1,6 @@
 EXPORTER_ID=myhost
 NODE_IP=127.0.0.1
-FILTER="\"container.name!=sf-collector and container.name!=sf-exporter\"" 
+FILTER="container.name!=sf-collector and container.name!=sf-exporter" 
 INTERVAL=300 
 ENABLE_DROP_MODE=1
 ENABLE_PROC_FLOW=0


### PR DESCRIPTION
Got the following error message when running with the default (after adding `container.type!=host`):
```
sf-collector    | Configured filter: "\"container.name!=sf-collector and container.name!=sf-exporter and container.type!=host\""
sf-collector    | E0124 23:27:24.299719     1 main.cpp:247] Runtime exception caught in main loop: filter error: unrecognized field \"container.name at pos
```

Deleting the `\"` around the string fixed the error, and now it boots up fine.