### PR TITLE
fixed broken link

### DIFF
--- a/integrations/elk/README.md
+++ b/integrations/elk/README.md
@@ -638,7 +638,7 @@ make -f Makefile.no_elk stop
 ## Licensing
 
 The code in repository as well as all SysFlow images are licensed
-under [Apache License 2.0](LICENSE.md). This deployment also uses
+under [Apache License 2.0](../../LICENSE.md). This deployment also uses
 [Anthony Lapenna's](https://github.com/deviantony) [ELK Stack on Docker](https://github.com/deviantony/docker-elk/tree/tls)
 which is licensed under [MIT license](https://github.com/deviantony/docker-elk/blob/tls/LICENSE).
 


### PR DESCRIPTION
Fixed the broken link to the SysFlow license in `integrations/elk/README.md`

Signed-off-by: Andreas Schade <san@zurich.ibm.com>