### PR TITLE
Changing CRI_PATH variables value to be read dynamically from values.…

### DIFF
--- a/helm/charts/sf-chart/templates/daemonset.yaml
+++ b/helm/charts/sf-chart/templates/daemonset.yaml
@@ -156,7 +156,7 @@ spec:
         - name: INTERVAL
           value: "{{ .Values.sfcollector.interval }}"
         - name: CRI_PATH
-          value: ""
+          value: "{{ .Values.sfcollector.criPath }}"
         - name: CRI_TIMEOUT
           value: "5"
         {{- if .Values.sfcollector.enableStats }}


### PR DESCRIPTION
Changing CRI_PATH variable's value to be read dynamically from values.yaml instead of having it static always.

Signed-off-by: Vishwas Prasanna <vkumar@intelops.dev>