### PR TITLE
Minor fixes in helm charts

### DIFF
--- a/helm/charts/sf-chart/templates/daemonset.yaml
+++ b/helm/charts/sf-chart/templates/daemonset.yaml
@@ -264,7 +264,7 @@ spec:
         - mountPath: /host/etc
           name: etc-fs
           readOnly: true
-        {{- if .Values.sfcollector.driverType "kmod" }}
+        {{- if eq .Values.sfcollector.driverType "kmod" }}
         - mountPath: /sys/module
           name: sysmodule
           readOnly: false
@@ -438,7 +438,7 @@ spec:
       - name: varlib
         hostPath:
           path: /var/lib
-      {{- if .Values.sfcollector.driverType "kmod" }}
+      {{- if eq .Values.sfcollector.driverType "kmod" }}
       - name: sysmodule 
         hostPath:
           path: /sys/module

--- a/helm/charts/sf-chart/templates/tests/test-collector-lsmod.yaml
+++ b/helm/charts/sf-chart/templates/tests/test-collector-lsmod.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if eq .Values.sfcollector.driverType "kmod" }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -53,3 +54,4 @@ spec:
   hostNetwork: false
   hostPID: false
   restartPolicy: Never
+{{- end }}


### PR DESCRIPTION
Hello,
I made a couple of fixes to be able to use the helm charts:
- fix(helm): missing eq in string comparison
- fix(helm): run lsmod test only when driverType is kmod

If you find this useful please consider merging this PR.

Thanks!